### PR TITLE
Fix USB to work again on firmware 5.x and up. Also remove the permissive flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(NXLINK_DEBUG),1)
 DEFINES +=	-DNXLINK_DEBUG
 endif
 
-ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -fpermissive
+ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 			$(ARCH) $(DEFINES) $(CFLAGS)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -49,8 +49,29 @@ u32 g_framebufHeight;
 bool g_shouldExit = false;
 int firmwareMajorVersion;
 
+// Below function copied from SwitchIdent (https://github.com/joel16/SwitchIdent)
+void getFirmwareVersion() {
+    Service setsys_service;
+    if (R_FAILED(setsysInitialize()))
+		fatalSimple(0xBEEB);
+
+	if (R_FAILED(smGetService(&setsys_service, "set:sys")))
+        fatalSimple(0xBEEC);
+
+    SetSysFirmwareVersion ver;
+	if (R_FAILED(setsysGetFirmwareVersion(&setsys_service, &ver)))
+	 	fatalSimple(0xBEED);
+
+    firmwareMajorVersion = (int) ver.version_long[28] - '0';
+
+    serviceClose(&setsys_service);
+    setsysExit();
+}
+
 void userAppInit(void)
 {
+    getFirmwareVersion();
+
     if (R_FAILED(ncmextInitialize()))
         fatalSimple(0xBEEF);
 
@@ -118,31 +139,10 @@ void markForExit(void)
     g_shouldExit = true;
 }
 
-// Below function copied from SwitchIdent (https://github.com/joel16/SwitchIdent)
-void getFirmwareVersion() {
-    Service setsys_service;
-    if (R_FAILED(setsysInitialize()))
-		fatalSimple(0xBEEB);
-
-	if (R_FAILED(smGetService(&setsys_service, "set:sys")))
-        fatalSimple(0xBEEC);
-
-    SetSysFirmwareVersion ver;
-	if (R_FAILED(setsysGetFirmwareVersion(&setsys_service, &ver)))
-	 	fatalSimple(0xBEED);
-
-    firmwareMajorVersion = (int) ver.version_long[28] - '0';
-
-    serviceClose(&setsys_service);
-    setsysExit();
-}
-
 int main(int argc, char **argv)
 {
     try
     {
-        getFirmwareVersion();
-
         Result rc = 0;
         tin::ui::ViewManager& manager = tin::ui::ViewManager::Instance();
 

--- a/source/nx/setsys.cpp
+++ b/source/nx/setsys.cpp
@@ -4,6 +4,16 @@
 
 #include "nx/setsys.hpp"
 
+typedef struct {
+    u64 magic;
+    u64 cmd_id;
+} IpcCommandHeader;
+
+typedef struct {
+    u64 magic;
+    u64 result;
+} IpcVersionResponse;
+
 static Result GetFirmwareVersion(Service *srv, SetSysFirmwareVersion *ver) {
     char buffer[0x100];
     size_t size = sizeof(buffer);
@@ -13,12 +23,9 @@ static Result GetFirmwareVersion(Service *srv, SetSysFirmwareVersion *ver) {
     ipcInitialize(&c);
     ipcAddRecvStatic(&c, buffer, size, 0);
 
-    struct {
-        u64 magic;
-        u64 cmd_id;
-    } *raw;
+    IpcCommandHeader * raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = (IpcCommandHeader *) ipcPrepareHeader(&c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 3;
@@ -29,10 +36,7 @@ static Result GetFirmwareVersion(Service *srv, SetSysFirmwareVersion *ver) {
         IpcParsedCommand r;
         ipcParse(&r);
 
-        struct {
-            u64 magic;
-            u64 result;
-        }* resp = r.Raw;
+        IpcVersionResponse * resp = (IpcVersionResponse *) r.Raw;
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)){
@@ -52,12 +56,9 @@ static Result GetFirmwareVersion2(Service *srv, SetSysFirmwareVersion *ver) {
     ipcInitialize(&c);
     ipcAddRecvStatic(&c, buffer, size, 0);
 
-    struct {
-        u64 magic;
-        u64 cmd_id;
-    } *raw;
+    IpcCommandHeader * raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = (IpcCommandHeader *) ipcPrepareHeader(&c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 4;
@@ -68,10 +69,7 @@ static Result GetFirmwareVersion2(Service *srv, SetSysFirmwareVersion *ver) {
         IpcParsedCommand r;
         ipcParse(&r);
 
-        struct {
-            u64 magic;
-            u64 result;
-        }* resp = r.Raw;
+        IpcVersionResponse * resp = (IpcVersionResponse *) r.Raw;
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)){


### PR DESCRIPTION
Sorry about the previous code. I only have a 4.1.0 hacked Switch, so it wasn't fully tested. Also didn't expect to get that merged in with the permissive flag. This should fix everything.